### PR TITLE
Enh: Allow predefined tags, attributes and non-ASCII characters

### DIFF
--- a/models/parser/TranslationPurifier.php
+++ b/models/parser/TranslationPurifier.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace humhub\modules\translation\models\parser;
-
 
 use yii\helpers\HtmlPurifier;
 
@@ -11,12 +9,16 @@ class TranslationPurifier extends HtmlPurifier
     /**
      * @inheritDoc
      */
-    public static function configure( $config)
+    public static function configure($config)
     {
-        // https://stackoverflow.com/questions/4566301/htmlpurifier-with-an-html5-doctype
+        // Set HTMLPurifier configuration
         $config->set('HTML.Doctype', 'HTML 4.01 Transitional');
-        $def =  $config->getHTMLDefinition(true);
-        $def->addAttribute('a', 'href', new ParameterURIDef());
-        $def->addAttribute('img', 'src', new ParameterURIDef());
+        $config->set('Attr.EnableID', true);
+
+        // Allow specific tags and attributes
+        $config->set('HTML.Allowed', 'p,b,i,u,s,a[href|target],img[src|alt],ul,ol,li,blockquote,code,pre,span,hr,br,strong');
+        
+        // Allow non-ASCII characters
+        $config->set('Core.EscapeNonASCIICharacters', false);
     }
 }


### PR DESCRIPTION
Alternative for #43 but also allows for non-ASCII characters to be used when translating in other languages.

resolves #49 