### PR TITLE
Fix tests: avoid escaping inside attributes `a[href]` and `img[src]`

### DIFF
--- a/models/parser/TranslationPurifier.php
+++ b/models/parser/TranslationPurifier.php
@@ -17,8 +17,13 @@ class TranslationPurifier extends HtmlPurifier
 
         // Allow specific tags and attributes
         $config->set('HTML.Allowed', 'p,b,i,u,s,a[href|target],img[src|alt],ul,ol,li,blockquote,code,pre,span,hr,br,strong');
-        
+
         // Allow non-ASCII characters
         $config->set('Core.EscapeNonASCIICharacters', false);
+
+        // To avoid escaping inside the attributes
+        $def = $config->getHTMLDefinition(true);
+        $def->addAttribute('a', 'href', new ParameterURIDef());
+        $def->addAttribute('img', 'src', new ParameterURIDef());
     }
 }


### PR DESCRIPTION
Fix errors in tests https://github.com/humhub/translation/actions/runs/8268396569/job/22621162486#step:25:127:

```
Excepted: <a href="{asdf}">{asdf}</a>
Actual: <a href="%7Basdf%7D">{asdf}</a>

Excepted: <img src="{asdf}" alt="Test">
Actual: <img src="%7Basdf%7D" alt="Test">
```

Related to changes from the PR https://github.com/humhub/translation/pull/61.